### PR TITLE
add required pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 mitmproxy~=10.0.0
+pyyaml~=6.0.1


### PR DESCRIPTION
This requirement was forgotten during platform migration.