### PR TITLE
Nextbike: vehicle_types_available fill-in

### DIFF
--- a/app/converters/gbfs_nextbike_vehicle_availabilities.py
+++ b/app/converters/gbfs_nextbike_vehicle_availabilities.py
@@ -4,7 +4,7 @@ Copyright (c) 2023, binary butterfly GmbH
 All rights reserved.
 """
 
-from typing import List, Union
+from typing import Any
 
 from app.base_converter import BaseConverter
 from app.utils.gbfs_util import update_stations_availability_status
@@ -25,11 +25,12 @@ class GbfsNextbikeVehicleAvailabilityConverter(BaseConverter):
     available at this station, or a vehicle_type which could be available sometimes
     will not appear in vehicle_types_available.
     """
+
     hostnames = ['gbfs.nextbike.net']
 
-    free_vehicles_cache_per_system = {}
+    free_vehicles_cache_per_system: dict[str, list[dict]] = {}
 
-    def convert(self, data: Union[dict, list], path: str) -> Union[dict, list]:
+    def convert(self, data: dict | list, path: str) -> dict | list:
         if (
             not isinstance(data, dict)
             or not path.startswith('/maps/gbfs/v2/')
@@ -44,16 +45,18 @@ class GbfsNextbikeVehicleAvailabilityConverter(BaseConverter):
 
         return self._convert_station_status(system_id, data, path)
 
-    def _get_system_id_from_path(self, path):
+    @staticmethod
+    def _get_system_id_from_path(path: str) -> str:
         return path.split('/')[-3:-2][0]
 
-    def _convert_free_vehicle_status(self, system_id: str, data: Union[dict, list], path: str) -> Union[dict, list]:
+    def _convert_free_vehicle_status(self, system_id: str, data: dict, path: str) -> dict:
         # cache vehicles per feed
         vehicles = data.get('data', {}).get('bikes', [])
-        self.free_vehicles_cache_per_system[system_id] = vehicles
+        if isinstance(vehicles, list):
+            self.free_vehicles_cache_per_system[system_id] = vehicles
         return data
 
-    def _convert_station_status(self, system_id: str, data: Union[dict, list], path: str) -> Union[dict, list]:
+    def _convert_station_status(self, system_id: str, data: dict, path: str) -> dict:
         if not data.get('data', {}).get('stations'):
             return data
 

--- a/app/utils/gbfs_util.py
+++ b/app/utils/gbfs_util.py
@@ -5,7 +5,7 @@ All rights reserved.
 """
 import logging
 from collections import Counter
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 
 def update_stations_availability_status(station_status: List[Dict], vehicles: List[Dict]) -> None:
@@ -46,7 +46,7 @@ def update_stations_availability_status(station_status: List[Dict], vehicles: Li
             station['vehicle_types_available'] = default_vehicle_types_available
 
 
-def _count_vehicle_types_at_station(vehicles, filter) -> Counter:
+def _count_vehicle_types_at_station(vehicles: list[dict[str, Any]], filter: Callable[[dict], bool]) -> Counter:
     """
     Count vehicle's per vehicle_type and station, which fulfill the filter critera.
     """
@@ -68,7 +68,8 @@ def _update_station_availability_status(vt_available: List[Dict[str, Any]], stat
     if 'num_bikes_available' in station_status:
         if num_bikes_available != station_status['num_bikes_available']:
             logging.warn(
-                f"Official num_bikes_available ({station_status['num_bikes_available']}) does not match count deduced from vehicle_types_available ({num_bikes_available}) at stationn {station_status['station_id']}"
+                f"Official num_bikes_available ({station_status['num_bikes_available']}) does not match count deduced "
+                + f" from vehicle_types_available ({num_bikes_available}) at stationn {station_status['station_id']}"
             )
     else:
         station_status['num_bikes_available'] = num_bikes_available


### PR DESCRIPTION
Nextbike feeds are currently invalid, as the `station_status`does not provide the propery `vehicle_types_available`.

This PR fills them in, as bikes at stations in `free_bike_status.json` have their station's id assigned.

The `GbfsNextbikeVehicleAvailabilityConverter` counts the number of vehicles per vehicle_type_id at each station and constructs the vehicle_types_available from this information.

In cases not a single vehicle is assigned to a station, we add a single vehicle_types_id with count == 0 as vehicle_types_available.

Note that this is a workaround and might be a vehicle_type that will never be  available at this station, or a vehicle_type which could be available sometimes will not appear in vehicle_types_available. 
