### PR TITLE
Add date-based docker image tag

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -27,12 +27,17 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ github.token }}
 
+    - name: set date-based tag
+      run: |
+        echo "DATE_TIME_TAG=$(date '+%Y-%m-%dT%H-%M')" >> $GITHUB_ENV
+
     - name: build and push Docker image
       uses: docker/build-push-action@v5
       with:
         push: true
         tags: |
           ghcr.io/${{ github.repository }}:latest
+          ghcr.io/${{ github.repository }}:${{ env.DATE_TIME_TAG }}
         platforms: linux/amd64,linux/arm64
         # https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api
         cache-from: type=gha


### PR DESCRIPTION
This PR introduces date-based image tags (`Y-%m-%dT%H-%M`) for docker images built on the main branch.