### PR TITLE
Add converter for data.lime.bike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+The changelog lists relevant feature changes between each release. Search GitHub issues and pull requests for smaller issues.
+
+## Upcoming release (under development)
+
+## 2024-06-14
+- add converter for `data.lime.bike` feed: remove `station_status` and `station_information` feeds from gbfs.json, as Lime associates all free floating bikes to a single station, which is semantically wrong.
+

--- a/app/converters/gbfs_lime_remove_stations.py
+++ b/app/converters/gbfs_lime_remove_stations.py
@@ -1,0 +1,32 @@
+"""
+MobiData BW Proxy
+Copyright (c) 2023, binary butterfly GmbH
+All rights reserved.
+"""
+
+from typing import List, Union
+
+from app.base_converter import BaseConverter
+
+
+class GbfsLimeRemoveStationsConverter(BaseConverter):
+    hostnames = ['data.lime.bike']
+
+    def convert(self, data: Union[dict, list], path: str) -> Union[dict, list]:
+        if not path.endswith('/gbfs.json') or not isinstance(data, dict) or not isinstance(data.get('data'), dict):
+            return data
+
+        for language in data['data']:
+            new_feeds = []
+            if not isinstance(data['data'][language].get('feeds'), list):
+                continue
+
+            for feed in data['data'][language]['feeds']:
+                if not isinstance(feed, dict) or feed.get('name') in ['station_information', 'station_status']:
+                    continue
+
+                new_feeds.append(feed)
+
+            data['data'][language]['feeds'] = new_feeds
+
+        return data

--- a/config_dist_dev.yaml
+++ b/config_dist_dev.yaml
@@ -3,3 +3,4 @@ HTTP_TO_HTTPS_HOSTS:
   - gbfs.nextbike.net
   - apis.deutschebahn.com
   - stables.donkey.bike
+  - data.lime.bike


### PR DESCRIPTION
This PR adds a converter for `data.lime.bike` feed, which removes `station_status` and `station_information` feeds from gbfs.json. They are removed as Lime associates all free floating bikes to a single station, which is semantically wrong. De facto, lime currently provides free-floating services.

