### PR TITLE
bird converter for removing empty feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The changelog lists relevant feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
 ## Upcoming release (under development)
+- add converter for `mds.bird.co` feed: remove `station_information`, `station_status` and `free_bike_status` feeds from gbfs.json if they are always empty.  
 
 ## 2024-06-14
 - add converter for `data.lime.bike` feed: remove `station_status` and `station_information` feeds from gbfs.json, as Lime associates all free floating bikes to a single station, which is semantically wrong.

--- a/app/converters/gbfs_bird_remove_stations_or_vehicles.py
+++ b/app/converters/gbfs_bird_remove_stations_or_vehicles.py
@@ -1,0 +1,34 @@
+from typing import List, Union
+
+from app.base_converter import BaseConverter
+
+
+class GbfsBirdRemoveStationsOrVehiclesConverter(BaseConverter):
+    hostnames = ['mds.bird.co']
+
+    @staticmethod
+    def _get_system_id_from_path(path: str) -> str:
+        return path.split('/')[-3:-2][0]
+
+    def convert(self, data: Union[dict, list], path: str) -> Union[dict, list]:
+        if not path.endswith('/gbfs.json') or not isinstance(data, dict) or not isinstance(data.get('data'), dict):
+            return data
+
+        system_id = self._get_system_id_from_path(path)
+        for language in data['data']:
+            if not isinstance(data['data'][language].get('feeds'), list):
+                continue
+
+            new_feeds = []
+            for feed in data['data'][language]['feeds']:
+                if not isinstance(feed, dict):
+                    continue
+                if system_id in ['basel', 'biel', 'kloten', 'zurich'] and feed.get('name') in ['station_information', 'station_status']:
+                    continue
+                if system_id in ['sarreguemines'] and feed.get('name') in ['free_bike_status']:
+                    continue
+                new_feeds.append(feed)
+
+            data['data'][language]['feeds'] = new_feeds
+
+        return data

--- a/config_dist_dev.yaml
+++ b/config_dist_dev.yaml
@@ -4,3 +4,4 @@ HTTP_TO_HTTPS_HOSTS:
   - apis.deutschebahn.com
   - stables.donkey.bike
   - data.lime.bike
+  - mds.bird.co


### PR DESCRIPTION
add converter for mds.bird.co feed: remove station_information, station_status and free_bike_status feeds from gbfs.json if they are always empty.