### PR TITLE
chore(deps): bump mitmproxy to version 11.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The changelog lists relevant feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
+## 2025-02-03:
+- chore(deps): bump mitmproxy to version 11.0.1
 
 ## 2025-01-29
 - add converter for `gbfs.api.ridedott.com` feeds: adjust station attributes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mitmproxy~=10.3.1
+mitmproxy~=11.0.1
 pyyaml~=6.0.2


### PR DESCRIPTION
This PR bumps mitmproxy to the current version 11.0.1 (see CHANGELOG)