### PR TITLE
fix request logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,12 @@ CMD [\
 	# > Log verbosity.
 	# > Default: info
 	# > Choices: error, warn, info, alert, debug
+	# > Flow Detail
+	# > Default: 1
+	# > Choices: 0, 1, 2, 3, 4
+	# > Set to 0, because request logging is done by addons.py
 	# https://docs.mitmproxy.org/stable/concepts-options/#available-options
-	"mitmdump -s addons.py --set termlog_verbosity=$LOG_LEVEL" \
+	"mitmdump -s addons.py --set termlog_verbosity=$LOG_LEVEL --set flow_detail=0" \
 ]
 
 # When sending an HTTP request with `Host: localhost`, mitmproxy will respond with 502.

--- a/app/app.py
+++ b/app/app.py
@@ -5,6 +5,7 @@ All rights reserved.
 """
 
 import json
+import logging
 from importlib import import_module
 from inspect import isclass
 from json import JSONDecodeError
@@ -18,6 +19,7 @@ from app.base_converter import BaseConverter
 from app.config_helper import ConfigHelper
 
 logger = logging.getLogger('converters.requests')
+
 
 class App:
     json_converters: Dict[str, List[BaseConverter]]

--- a/app/app.py
+++ b/app/app.py
@@ -54,7 +54,7 @@ class App:
 
     def response(self, flow: HTTPFlow):
         # Log requests
-        logger.info(f'GET {flow.request.url}: HTTP {flow.response.status_code}')
+        logger.info(f'GET {flow.request.url}: HTTP {"-" if flow.response is None else flow.response.status_code}')
 
         # if there is no converter for the requested host, don't do anything
         if flow.request.host not in self.json_converters:

--- a/app/app.py
+++ b/app/app.py
@@ -17,6 +17,7 @@ from mitmproxy.http import HTTPFlow
 from app.base_converter import BaseConverter
 from app.config_helper import ConfigHelper
 
+logger = logging.getLogger('converters.requests')
 
 class App:
     json_converters: Dict[str, List[BaseConverter]]
@@ -50,6 +51,9 @@ class App:
             flow.request.port = 443
 
     def response(self, flow: HTTPFlow):
+        # Log requests
+        logger.info(f'GET {flow.request.url}: HTTP {flow.response.status_code}')
+
         # if there is no converter for the requested host, don't do anything
         if flow.request.host not in self.json_converters:
             return

--- a/app/app.py
+++ b/app/app.py
@@ -54,7 +54,7 @@ class App:
 
     def response(self, flow: HTTPFlow):
         # Log requests
-        logger.info(f'GET {flow.request.url}: HTTP {"-" if flow.response is None else flow.response.status_code}')
+        logger.info(f'{flow.request.method} {flow.request.url}: HTTP {"-" if flow.response is None else flow.response.status_code}')
 
         # if there is no converter for the requested host, don't do anything
         if flow.request.host not in self.json_converters:


### PR DESCRIPTION
Turned out that the cut off urls does not even use logging, but the mitmproxy flow output which is based on terminal width (urgs!). The option `flow_detail` is per default on 1, which cuts off urls. Option 2 does not cut off urls, but outputs all headers, too, which is just spammy. Therefore, I switched the mitmproxy flow output to 0, which means no output, and did actual logging via `addons.py`.