### PR TITLE
converter to set return_constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The changelog lists relevant feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
-## 2025-05-02:
+## 2025-05-05:
 - add converter for all feeds: set return_constraint if not defined
 
 ## 2025-04-09:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog lists relevant feature changes between each release. Search GitHub issues and pull requests for smaller issues.
 
+## 2025-05-02:
+- add converter for all feeds: set return_constraint if not defined
+
 ## 2025-04-09:
 - add converter for all feeds: override ttl=0
 

--- a/app/converters/gbfs_https_to_http.py
+++ b/app/converters/gbfs_https_to_http.py
@@ -20,6 +20,7 @@ class GbfsHttpsToHttpConverter(BaseConverter):
         'api.voiapp.io',
         'gbfs.api.ridedott.com',
         'zeus.city',
+        'yoio.rideatom.com',
     ]
 
     def convert(self, data: Union[dict, list], path: str) -> Union[dict, list]:

--- a/app/converters/gbfs_https_to_http.py
+++ b/app/converters/gbfs_https_to_http.py
@@ -19,6 +19,7 @@ class GbfsHttpsToHttpConverter(BaseConverter):
         'gbfs.prod.sharedmobility.ch',
         'api.voiapp.io',
         'gbfs.api.ridedott.com',
+        'zeus.city',
     ]
 
     def convert(self, data: Union[dict, list], path: str) -> Union[dict, list]:

--- a/app/converters/gbfs_set_return_constraint.py
+++ b/app/converters/gbfs_set_return_constraint.py
@@ -1,0 +1,40 @@
+from typing import Union
+
+from app.base_converter import BaseConverter
+
+
+class GbfsSetReturnConstraintConverter(BaseConverter):
+    hostnames = [
+        'gbfs.nextbike.net',
+        'apis.deutschebahn.com',
+        'stables.donkey.bike',
+        'data.lime.bike',
+        'mds.bird.co',
+        'gbfs.prod.sharedmobility.ch',
+        'api.voiapp.io',
+        'gbfs.api.ridedott.com',
+    ]
+
+    # ensure that return_constraint is always set
+    # this attribute is necessary for intermodal routing
+    def convert(self, data: Union[dict, list], path: str) -> Union[dict, list]:
+        if not isinstance(data, dict):
+            return data
+
+        if path.endswith(('/vehicle_types', '/vehicle_types.json')):
+            fields = data.get('data')
+            if not isinstance(fields, dict):
+                return data
+            vehicle_types = fields.get('vehicle_types')
+            if not isinstance(vehicle_types, list):
+                return data
+            for vehicle_type in vehicle_types:
+                if 'return_constraint' in vehicle_type:
+                    continue
+                if path.startswith('/db-api-marketplace/apis/shared-mobility-gbfs/v2/de/RegioRadStuttgart'):
+                    vehicle_type['return_constraint'] = 'any_station'
+                if path.startswith('/maps/gbfs/v2/nextbike_df'):
+                    vehicle_type['return_constraint'] = 'any_station'
+            return data
+
+        return data

--- a/app/converters/gbfs_set_return_constraint.py
+++ b/app/converters/gbfs_set_return_constraint.py
@@ -14,6 +14,7 @@ class GbfsSetReturnConstraintConverter(BaseConverter):
         'api.voiapp.io',
         'gbfs.api.ridedott.com',
         'zeus.city',
+        'yoio.rideatom.com',
     ]
 
     # ensure that return_constraint is always set

--- a/app/converters/gbfs_set_return_constraint.py
+++ b/app/converters/gbfs_set_return_constraint.py
@@ -13,6 +13,7 @@ class GbfsSetReturnConstraintConverter(BaseConverter):
         'gbfs.prod.sharedmobility.ch',
         'api.voiapp.io',
         'gbfs.api.ridedott.com',
+        'zeus.city',
     ]
 
     # ensure that return_constraint is always set
@@ -31,10 +32,14 @@ class GbfsSetReturnConstraintConverter(BaseConverter):
             for vehicle_type in vehicle_types:
                 if 'return_constraint' in vehicle_type:
                     continue
-                if path.startswith('/db-api-marketplace/apis/shared-mobility-gbfs/v2/de/RegioRadStuttgart'):
-                    vehicle_type['return_constraint'] = 'any_station'
-                if path.startswith('/maps/gbfs/v2/nextbike_df'):
-                    vehicle_type['return_constraint'] = 'any_station'
+                if vehicle_type.get('form_factor', '') == 'bicycle':
+                    vehicle_type['return_constraint'] = 'any_station'  # valid for most providers
+                if vehicle_type.get('form_factor', '') == 'scooter':
+                    vehicle_type['return_constraint'] = 'free_floating'  # valid for most providers
+                if path.startswith('/maps/gbfs/v2/nextbike_fg'):
+                    vehicle_type['return_constraint'] = 'hybrid'
+                if path.startswith('/public/v2/'):  # dott feed
+                    vehicle_type['return_constraint'] = 'hybrid'
             return data
 
         return data

--- a/config_dist_dev.yaml
+++ b/config_dist_dev.yaml
@@ -8,3 +8,4 @@ HTTP_TO_HTTPS_HOSTS:
   - gbfs.prod.sharedmobility.ch
   - api.voiapp.io
   - gbfs.api.ridedott.com
+  - zeus.city

--- a/config_dist_dev.yaml
+++ b/config_dist_dev.yaml
@@ -9,3 +9,4 @@ HTTP_TO_HTTPS_HOSTS:
   - api.voiapp.io
   - gbfs.api.ridedott.com
   - zeus.city
+  - yoio.rideatom.com


### PR DESCRIPTION
transitous.org asked us to set return_constraint=any_station für RegioRad Stuttgart because this attribute is required for their intermodeal routing. the ipl-proxy has been developed such, that return_constraint can be set also for other operators.